### PR TITLE
allow options to pass through

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ gulpError = function(message) {
 module.exports = function (options) {
 	"use strict";
 
-  if (!options || typeof op !== 'object') {
+  if (!options || typeof options !== 'object') {
     options = {};
   }
 


### PR DESCRIPTION
Fixed typo which prevented any custom options from being used (such as a custom template).
